### PR TITLE
Feat: 로그인, 로그아웃 - FcmToken 관리 로직 추가

### DIFF
--- a/src/main/java/com/example/DoroServer/global/jwt/JwtLogoutHandler.java
+++ b/src/main/java/com/example/DoroServer/global/jwt/JwtLogoutHandler.java
@@ -3,6 +3,7 @@ package com.example.DoroServer.global.jwt;
 import static com.example.DoroServer.global.common.Constants.AUTHORIZATION_HEADER;
 import static com.example.DoroServer.global.common.Constants.REDIS_REFRESH_TOKEN_PREFIX;
 
+import com.example.DoroServer.domain.token.service.TokenService;
 import com.example.DoroServer.global.common.SuccessResponse;
 import com.example.DoroServer.global.exception.Code;
 import com.example.DoroServer.global.exception.JwtAuthenticationException;
@@ -23,6 +24,7 @@ public class JwtLogoutHandler implements LogoutHandler {
 
     private final JwtTokenProvider tokenProvider;
     private final RedisService redisService;
+    private final TokenService tokenService;
 
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response,
@@ -41,5 +43,11 @@ public class JwtLogoutHandler implements LogoutHandler {
         }
         Long expiration = tokenProvider.getExpiration(accessToken);
         redisService.setValues(accessToken, "logout", Duration.ofMillis(expiration));
+
+        String fcmToken = request.getHeader("fcmToken");
+        if (fcmToken != null) {
+            Long userId = Long.valueOf(tokenProvider.getUserId(accessToken));
+            tokenService.deleteToken(userId, fcmToken);
+        }
     }
 }

--- a/src/main/java/com/example/DoroServer/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/DoroServer/global/jwt/JwtTokenProvider.java
@@ -8,7 +8,6 @@ import com.example.DoroServer.global.exception.Code;
 import com.example.DoroServer.global.exception.JwtAuthenticationException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.SecurityException;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
@@ -20,12 +19,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import javax.annotation.PostConstruct;
-import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Date;
-import java.util.List;
 
 
 @Component
@@ -94,6 +91,16 @@ public class JwtTokenProvider {
         try {
             return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody()
                 .getSubject();
+        }catch (ExpiredJwtException e){
+            log.info("AccessToken 만료 시 재발급 = {}", e.getClaims().toString());
+            return e.getClaims().getSubject();
+        }
+    }
+
+    public String getUserId(String token) {
+        try {
+            return String.valueOf(
+                Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().get("id"));
         }catch (ExpiredJwtException e){
             log.info("AccessToken 만료 시 재발급 = {}", e.getClaims().toString());
             return e.getClaims().getSubject();


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
- Ju-yeop/main -> Doro-Server/develop

### 변경 사항
- JwtTokenProvier에 getUserId 메서드 추기
- Login, Logout 메서드에 각각 FcmToken 저장, 삭제 로직 추가

### 테스트 결과
- Postman 테스트 완료
