### PR TITLE
Fix: 알림 전송 오류 해결

### DIFF
--- a/src/main/java/com/example/DoroServer/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/DoroServer/domain/user/repository/UserRepository.java
@@ -27,7 +27,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query(value = "update User u set u.profileImg = :profile_img where u.id = :userId")
     void updateProfileImgById(@Param("userId") Long userId, @Param("profile_img") String profile_img);
 
-    @Query("SELECT u FROM User u INNER JOIN FETCH u.tokens")
+    @Query("SELECT DISTINCT u FROM User u INNER JOIN FETCH u.tokens")
     List<User> findAllWithTokens();
 
     @Query("SELECT u FROM User u LEFT JOIN FETCH u.tokens WHERE u.id = :id")


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Ju-yeop/main -> Doro-Server/develop

### 변경 사항
- 기존 쿼리 : Left Join → 모든 유저 다 불러옴
    → Inner Join → 토큰을 가지고 있는 유저를 불러옴 (한 유저가 토큰이 2개면 튜플 2개)  그런데 아래에서 users.getTokens로 각 튜플에 대해 user_id값이 일치하는 모든 토큰 튜플을 한번 더 조인해서 가져온다 N^2 → DISTINCT로 처음 쿼리문에서 불러오는 유저 중복제거
    
- 기존 서비스 로직: 알림 전송 성공 유무 확인하지 않고 안하고 무조건 저장, Left Join한 것 그대로 user_notification, notification에 모두 저장
    → notification 테이블에는 최초 1회 저장 후 알림 전송이 모두 실패했을 경우에 삭제 - user_notification에는 전송 성공 시 마다 저장
