### PR TITLE
Refact: 로그인 API 응답 타입 변경 (#102)

### DIFF
--- a/src/main/java/com/example/DoroServer/global/auth/AuthController.java
+++ b/src/main/java/com/example/DoroServer/global/auth/AuthController.java
@@ -6,11 +6,11 @@ import com.example.DoroServer.domain.user.entity.User;
 import com.example.DoroServer.global.auth.dto.ChangePasswordReq;
 import com.example.DoroServer.global.auth.dto.JoinReq;
 import com.example.DoroServer.global.auth.dto.LoginReq;
+import com.example.DoroServer.global.auth.dto.LoginRes;
 import com.example.DoroServer.global.auth.dto.ReissueReq;
 import com.example.DoroServer.global.common.SuccessResponse;
 import com.example.DoroServer.global.jwt.JwtTokenProvider;
 import com.example.DoroServer.global.jwt.RedisService;
-import com.mysema.commons.lang.Pair;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import javax.validation.Valid;
@@ -54,10 +54,10 @@ public class AuthController {
     public ResponseEntity<?> login (@RequestBody @Valid LoginReq loginReq,
                                     @RequestHeader(required = false) String fcmToken,
                                     @RequestHeader("User-Agent") String userAgent){
-        Pair<HttpHeaders, String> result = authService.login(loginReq, fcmToken, userAgent);
+        LoginRes result = authService.login(loginReq, fcmToken, userAgent);
         return ResponseEntity.ok()
-            .headers(result.getFirst())
-            .body(result.getSecond());
+            .headers(result.getAccessTokenHeader())
+            .body(result.getRefreshToken());
     }
 
     @Operation(summary = "001_03", description = "아이디 중복체크")

--- a/src/main/java/com/example/DoroServer/global/auth/AuthService.java
+++ b/src/main/java/com/example/DoroServer/global/auth/AuthService.java
@@ -4,6 +4,7 @@ import com.example.DoroServer.domain.user.entity.User;
 import com.example.DoroServer.global.auth.dto.ChangePasswordReq;
 import com.example.DoroServer.global.auth.dto.JoinReq;
 import com.example.DoroServer.global.auth.dto.LoginReq;
+import com.example.DoroServer.global.auth.dto.LoginRes;
 import com.example.DoroServer.global.auth.dto.ReissueReq;
 import com.mysema.commons.lang.Pair;
 import org.springframework.http.HttpHeaders;
@@ -22,7 +23,7 @@ public interface AuthService {
 
     void checkPhoneNumber(String phone);
 
-    Pair<HttpHeaders, String> login(LoginReq loginReq, String fcmToken, String userAgent);
+    LoginRes login(LoginReq loginReq, String fcmToken, String userAgent);
 
     HttpHeaders reissue(ReissueReq reissueReq, String userAgent);
 }

--- a/src/main/java/com/example/DoroServer/global/auth/AuthServiceImpl.java
+++ b/src/main/java/com/example/DoroServer/global/auth/AuthServiceImpl.java
@@ -17,6 +17,7 @@ import com.example.DoroServer.domain.userNotification.repository.UserNotificatio
 import com.example.DoroServer.global.auth.dto.ChangePasswordReq;
 import com.example.DoroServer.global.auth.dto.JoinReq;
 import com.example.DoroServer.global.auth.dto.LoginReq;
+import com.example.DoroServer.global.auth.dto.LoginRes;
 import com.example.DoroServer.global.auth.dto.ReissueReq;
 import com.example.DoroServer.global.common.Constants.REDIS_MESSAGE_PREFIX;
 import com.example.DoroServer.global.exception.BaseException;
@@ -24,7 +25,6 @@ import com.example.DoroServer.global.exception.Code;
 import com.example.DoroServer.global.exception.JwtAuthenticationException;
 import com.example.DoroServer.global.jwt.JwtTokenProvider;
 import com.example.DoroServer.global.jwt.RedisService;
-import com.mysema.commons.lang.Pair;
 import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -177,7 +177,7 @@ public class AuthServiceImpl implements AuthService{
     }
 
     @Override
-    public Pair<HttpHeaders, String> login(LoginReq loginReq, String fcmToken, String userAgent) {
+    public LoginRes login(LoginReq loginReq, String fcmToken, String userAgent) {
         UsernamePasswordAuthenticationToken authenticationToken =
                 new UsernamePasswordAuthenticationToken(loginReq.getAccount(), loginReq.getPassword());
 
@@ -195,7 +195,7 @@ public class AuthServiceImpl implements AuthService{
             tokenService.saveToken(userId, fcmToken);
         }
 
-        return new Pair<>(httpHeaders, refreshToken);
+        return new LoginRes(httpHeaders, refreshToken);
     }
 
     @Override

--- a/src/main/java/com/example/DoroServer/global/auth/dto/LoginRes.java
+++ b/src/main/java/com/example/DoroServer/global/auth/dto/LoginRes.java
@@ -1,0 +1,12 @@
+package com.example.DoroServer.global.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.http.HttpHeaders;
+
+@Data
+@AllArgsConstructor
+public class LoginRes {
+    HttpHeaders accessTokenHeader;
+    String refreshToken;
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Ju-yeop/102-refact-security -> Doro-Server/develop

### 변경 사항
로그인 서비스의 응답 타입을 변경했습니다.
Pair -> LoginRes
