### PR TITLE
Fix: 개인 알림 전송 로직 오류 수정 #94

### DIFF
--- a/src/main/java/com/example/DoroServer/domain/userNotification/service/UserNotificationService.java
+++ b/src/main/java/com/example/DoroServer/domain/userNotification/service/UserNotificationService.java
@@ -72,7 +72,7 @@ public class UserNotificationService {
                 UserNotification.builder()
                         .user(user)
                         .notification(notification)
-//                        .expirationPeriod(LocalDateTime.now().plusMonths(3))
+                        .isRead(false)
                         .build());
 
         return userNotification.getId();


### PR DESCRIPTION
개인 알림 저장시 읽음 여부 builder 에 추가

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
weightsforfun/94-refact-알림-도메인 -> DOROEDU/94-refact-알림-도메인

### 변경 사항
개인 알람 전송에 isRead(알림 조회 여부)를  builder 에 추가했습니다.

### 테스트 결과
postman으로 테스트 완료
